### PR TITLE
Handle 303 Responses correctly

### DIFF
--- a/presence.js
+++ b/presence.js
@@ -50,8 +50,13 @@ function login(username, password) {
 
 function poll() {
     loadToken().then(token => {
-	    request(apiUrl, {auth: {bearer: token}}, (err, res, body) => {
+	    request(apiUrl, {auth: {bearer: token}, followRedirect: false}, (err, res, body) => {
 		    if (!err) {
+		    	if(res.statusCode === 303) {
+		    		console.log('Token invalid, got redirect from service. Removing Token and retrying next time.');
+		    		dataService.setToken(undefined);
+		    		return;
+			    }
 			    let curPresence = JSON.parse(body);
 			    let lastPresence = dataService.getPresence();
 			    let joined = curPresence.filter(comparer(lastPresence));


### PR DESCRIPTION
In normalem Betrieb sollte das Token erneuert werden, falls es abgelaufen ist, falls das aber nicht rein clientseitig feststellbar ist, und der Service einen 303er auf die Loginseite schickt, wird das Token gelöscht und beim nächsten Mal erneut angefordert. Es wird bis zum nächsten Intervall gewartet, damit keine Endlosschleife entsteht, falls der Login-Server und der Presence-Service inkompatible Tokens herausgeben.